### PR TITLE
Update: GitHub actions versions and npm publishing (fix #13)

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -15,11 +15,11 @@ jobs:
       id-token: write # to enable use of OIDC for trusted publishing and npm provenance
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
       - name: Update npm

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "adapt-schemas",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cgkineo/adapt-schemas"
+  },
   "version": "1.0.3",
   "description": "Standalone JSON Schema library for the Adapt framework",
   "type": "module",


### PR DESCRIPTION
Fix #13 

### Update
* _releases.yml_: Bump `actions/checkout` and `actions/setup-node` versions to v4
* _package.json_: Added `repository` object for npm publishing
* _.npmignore_: Added npm ignore file. Duplicate of _.gitignore_. Supresses npm warning for `gitignore-fallback`.

