### PR TITLE
New: Add walk function for retrieving specific schema paths (fixes #12)

### DIFF
--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -373,6 +373,33 @@ class Schema extends EventEmitter {
         : s.default
     })
   }
+
+  /**
+   * Walks the built schema alongside data, returning fields matching a predicate.
+   * @param {Object} data - The data object to walk
+   * @param {Function} predicate - `(schemaField) => boolean`
+   * @param {Object} [schema] - Internal: schema properties to walk (defaults to built.properties)
+   * @param {string} [parentPath=''] - Internal: the slash-delimited path accumulated so far
+   * @returns {Array<Object>} Array of `{ path, key, data, value }` matches
+   */
+  walk (data, predicate, schema, parentPath = '') {
+    schema = schema ?? this.built.properties
+    const matches = []
+    for (const [key, val] of Object.entries(schema)) {
+      if (data[key] === undefined) continue
+      const currentPath = parentPath ? `${parentPath}/${key}` : key
+      if (val.properties) {
+        matches.push(...this.walk(data[key], predicate, val.properties, currentPath))
+      } else if (val?.items?.properties) {
+        data[key].forEach((item, i) => {
+          matches.push(...this.walk(item, predicate, val.items.properties, `${currentPath}/${i}`))
+        })
+      } else if (predicate(val)) {
+        matches.push({ path: currentPath, key, data, value: data[key] })
+      }
+    }
+    return matches
+  }
 }
 
 export default Schema

--- a/test.js
+++ b/test.js
@@ -274,6 +274,27 @@ async function runTests () {
     await library.registerSchema(newSchemaPath)
     console.log('')
 
+    // Test 11: Schema.walk
+    console.log('Test 11: Schema.walk')
+    const courseSchema = await library.getSchema('course')
+    const walkData = {
+      title: 'Test',
+      description: 'A course',
+      _globals: {
+        _accessibility: {
+          _isEnabled: true,
+          skipNavigationText: 'Skip'
+        }
+      }
+    }
+    const stringFields = courseSchema.walk(walkData, val => val.type === 'string')
+    const paths = stringFields.map(r => r.path)
+    console.log(`  ✓ Found ${stringFields.length} string fields: ${paths.join(', ')}`)
+    const hasTitle = paths.includes('title')
+    const hasNested = paths.includes('_globals/_accessibility/skipNavigationText')
+    console.log(`  ✓ Includes top-level field: ${hasTitle}`)
+    console.log(`  ✓ Includes nested field: ${hasNested}\n`)
+
     console.log('=== All tests passed! ===')
   } finally {
     if (!hasSpecifiedPath) {


### PR DESCRIPTION
Fixes #12

### New
* Add `Schema#walk(data, predicate)` function that recursively walks a schema alongside data, returning array of `{ path, key, data, value }` matches for fields matching the predicate:
  * Predicate function to return truthy to trigger a match
  * Paths are slash-delimited and include array indices (e.g. `_items/0/_graphic/src`)
  * Returned `data` references allow in-place mutation of matched values

### Testing
1. `npm test`

---

### Examples
```js
// Translatable:
schema.walk(data, field => field?.translatable === true) 

// Assets:
schema.walk(data, field => {
  return field?._backboneForms?.type === 'Asset' || field?._backboneForms === 'Asset')
})
```