### PR TITLE
Fix: Make sure we return the built schema, not the Schema instance (fixes #19)

### DIFF
--- a/lib/Schemas.js
+++ b/lib/Schemas.js
@@ -65,7 +65,7 @@ class Schemas extends EventEmitter {
       addUsedSchema: false,
       allErrors: true,
       allowUnionTypes: true,
-      loadSchema: this.getSchema.bind(this),
+      loadSchema: async (uri) => (await this.getSchema(uri, { compile: false })).built,
       removeAdditional: 'all',
       strict: false,
       verbose: true,


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #19

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Return the `.built` schema instead of the `Schema` instance on `loadSchema`. Passing the class causes AJV to traverse the instance as though it's a schema, causing issues.



