### PR TITLE
Fix: Sync simple schemas to AJV's internal store (fixes #33)

### DIFF
--- a/lib/Schemas.js
+++ b/lib/Schemas.js
@@ -231,7 +231,7 @@ class Schemas extends EventEmitter {
 
     this.schemas[schema.name] = schema
 
-    // AJV's sync compile() can only resolve $refs against schemas in its internal storeto allow `$ref: "schemaName`"
+    // AJV's sync compile() can only resolve $refs against schemas in its internal store to allow `$ref: "schemaName`"
     // Note we only add simple schemas (no $merge/$patch)
     if (!schema.raw.$merge && !schema.raw.$patch) {
       for (const v of [this.validator, this.validatorWithDefaults]) {

--- a/lib/Schemas.js
+++ b/lib/Schemas.js
@@ -110,6 +110,12 @@ class Schemas extends EventEmitter {
    * Empties the schema registry (with the exception of the base schema)
    */
   resetSchemaRegistry () {
+    // Remove previously registered schemas from AJV instances
+    for (const name of Object.keys(this.schemas)) {
+      for (const v of [this.validator, this.validatorWithDefaults]) {
+        if (v.getSchema(name)) v.removeSchema(name)
+      }
+    }
     this.schemas = {
       base: this.createSchema(path.resolve(__dirname, BASE_SCHEMA_PATH), { enableCache: true })
     }
@@ -224,6 +230,16 @@ class Schemas extends EventEmitter {
     }
 
     this.schemas[schema.name] = schema
+
+    // AJV's sync compile() can only resolve $refs against schemas in its internal storeto allow `$ref: "schemaName`"
+    // Note we only add simple schemas (no $merge/$patch)
+    if (!schema.raw.$merge && !schema.raw.$patch) {
+      for (const v of [this.validator, this.validatorWithDefaults]) {
+        if (v.getSchema(schema.name)) v.removeSchema(schema.name)
+        v.addSchema(schema.raw, schema.name)
+      }
+    }
+
     this.schemaExtensions?.[schema.name]?.forEach(s => schema.addExtension(s))
 
     if (schema.raw.$patch) {
@@ -241,6 +257,10 @@ class Schemas extends EventEmitter {
   deregisterSchema (name) {
     if (this.schemas[name]) {
       delete this.schemas[name]
+    }
+    // Remove from AJV instances
+    for (const v of [this.validator, this.validatorWithDefaults]) {
+      if (v.getSchema(name)) v.removeSchema(name)
     }
     // Remove schema from any extensions lists
     Object.entries(this.schemaExtensions).forEach(([base, extensions]) => {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
#33

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Maintain AJV's internal schema store to allow synchronous schema resolution

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Add schema with `$ref` schema (e.g. [authroutes](https://github.com/adapt-security/adapt-authoring-auth/blob/master/schema/authroutes.schema.json) references [routeitem](https://github.com/adapt-security/adapt-authoring-server/blob/master/schema/routeitem.schema.json))