### PR TITLE
Breaking: keep extension relationships on the library only (fixes #37)

### DIFF
--- a/lib/Schema.js
+++ b/lib/Schema.js
@@ -46,12 +46,6 @@ class Schema extends EventEmitter {
     this.enableCache = enableCache
 
     /**
-     * List of extensions for this schema
-     * @type {string[]}
-     */
-    this.extensions = []
-
-    /**
      * File path to the schema
      * @type {string}
      */
@@ -195,14 +189,13 @@ class Schema extends EventEmitter {
       parent = parent.getParent()
     }
 
-    if (this.extensions.length) {
-      this.extensions.forEach(s => {
-        const applyPatch = typeof extensionFilter === 'function' ? extensionFilter(s) : applyExtensions !== false
-        if (!applyPatch) return
-        const extSchema = this.schemaLibrary.getSchema(s)
-        this.patch(built, extSchema.raw, { extendAnnotations: false })
-      })
-    }
+    const extensions = this.schemaLibrary.schemaExtensions?.[this.name] ?? []
+    extensions.forEach(s => {
+      const applyPatch = typeof extensionFilter === 'function' ? extensionFilter(s) : applyExtensions !== false
+      if (!applyPatch) return
+      const extSchema = this.schemaLibrary.getSchema(s)
+      this.patch(built, extSchema.raw, { extendAnnotations: false })
+    })
 
     this.built = built
 
@@ -355,13 +348,14 @@ class Schema extends EventEmitter {
   }
 
   /**
-   * Adds an extension schema
-   * @param {string} extSchemaName Extension schema name
+   * Discards any cached build/compiled state. Called when an extension is added
+   * or removed against this schema so the next `build()` reflects the change.
    */
-  addExtension (extSchemaName) {
-    if (!this.extensions.includes(extSchemaName)) {
-      this.extensions.push(extSchemaName)
-    }
+  invalidateBuild () {
+    this.built = undefined
+    this.compiled = undefined
+    this.compiledWithDefaults = undefined
+    this.lastBuildTime = undefined
   }
 
   /**

--- a/lib/Schemas.js
+++ b/lib/Schemas.js
@@ -42,7 +42,7 @@ class Schemas extends EventEmitter {
     this.schemas = {}
 
     /**
-     * Temporary store of extension schemas
+     * Maps base schema name to the names of schemas that extend it (via $patch).
      * @type {Object<string, string[]>}
      */
     this.schemaExtensions = {}
@@ -119,6 +119,7 @@ class Schemas extends EventEmitter {
     this.schemas = {
       base: this.createSchema(path.resolve(__dirname, BASE_SCHEMA_PATH), { enableCache: true })
     }
+    this.schemaExtensions = {}
     this.emit('reset')
   }
 
@@ -240,8 +241,6 @@ class Schemas extends EventEmitter {
       }
     }
 
-    this.schemaExtensions?.[schema.name]?.forEach(s => schema.addExtension(s))
-
     if (schema.raw.$patch) {
       this.extendSchema(schema.raw.$patch?.source?.$ref, schema.name)
     }
@@ -255,17 +254,16 @@ class Schemas extends EventEmitter {
    * @param {string} name Schema name to deregister
    */
   deregisterSchema (name) {
-    if (this.schemas[name]) {
-      delete this.schemas[name]
-    }
-    // Remove from AJV instances
+    delete this.schemas[name]
     for (const v of [this.validator, this.validatorWithDefaults]) {
       if (v.getSchema(name)) v.removeSchema(name)
     }
-    // Remove schema from any extensions lists
-    Object.entries(this.schemaExtensions).forEach(([base, extensions]) => {
+    delete this.schemaExtensions[name]
+    for (const [base, extensions] of Object.entries(this.schemaExtensions)) {
+      if (!extensions.includes(name)) continue
       this.schemaExtensions[base] = extensions.filter(s => s !== name)
-    })
+      this.schemas[base]?.invalidateBuild()
+    }
     this.emit('schemaDeregistered', name)
   }
 
@@ -286,9 +284,6 @@ class Schemas extends EventEmitter {
       ...options
     })
 
-    this.schemaExtensions?.[schema.name]?.forEach(s => schema.addExtension(s))
-    delete this.schemaExtensions?.[schema.name]
-
     return schema.load()
   }
 
@@ -298,14 +293,12 @@ class Schemas extends EventEmitter {
    * @param {string} extSchemaName The name of the schema to extend with
    */
   extendSchema (baseSchemaName, extSchemaName) {
-    const baseSchema = this.schemas[baseSchemaName]
-    if (baseSchema) {
-      baseSchema.addExtension(extSchemaName)
-    } else {
-      if (!this.schemaExtensions[baseSchemaName]) {
-        this.schemaExtensions[baseSchemaName] = []
-      }
+    if (!this.schemaExtensions[baseSchemaName]) {
+      this.schemaExtensions[baseSchemaName] = []
+    }
+    if (!this.schemaExtensions[baseSchemaName].includes(extSchemaName)) {
       this.schemaExtensions[baseSchemaName].push(extSchemaName)
+      this.schemas[baseSchemaName]?.invalidateBuild()
     }
     this.emit('schemaExtended', baseSchemaName, extSchemaName)
   }
@@ -367,7 +360,7 @@ class Schemas extends EventEmitter {
     return Object.entries(this.schemas).reduce((info, [name, schema]) => {
       info[name] = {
         filePath: schema.filePath,
-        extensions: schema.extensions,
+        extensions: this.schemaExtensions[name] ?? [],
         hasParent: !!schema.raw?.$merge?.source?.$ref,
         isPatch: !!schema.raw?.$patch
       }

--- a/lib/Schemas.js
+++ b/lib/Schemas.js
@@ -307,7 +307,7 @@ class Schemas extends EventEmitter {
    * Retrieves the specified schema
    * @param {string} schemaName The name of the schema to return
    * @param {Object} options
-   * @param {boolean} options.useCache Use cached build if available
+   * @param {boolean} options.useCache When false, builds into a fresh isolated Schema instance so per-call options (extensionFilter, applyExtensions) don't mutate the registry's build state (default: true)
    * @param {boolean} options.compile Compile the schema (default: true)
    * @param {boolean} options.applyExtensions Apply extension schemas (default: true)
    * @param {function} options.extensionFilter Filter function for extensions
@@ -318,7 +318,10 @@ class Schemas extends EventEmitter {
     if (!schema) {
       throw new SchemaError('MISSING_SCHEMA', `Schema '${schemaName}' not found`, { schemaName })
     }
-    return schema.build(options)
+    if (options.useCache !== false) return schema.build(options)
+    // build into a fresh instance so per-call options (e.g. extensionFilter) don't mutate the registry
+    const isolated = this.createSchema(schema.filePath, { enableCache: false })
+    return isolated.build(options)
   }
 
   /**

--- a/test.js
+++ b/test.js
@@ -886,6 +886,28 @@ async function runTests () {
     }
     console.log('')
 
+    // Test 25: useCache:false isolates filtered builds from the registry instance
+    console.log('Test 25: useCache:false isolates filtered builds from the registry instance')
+    const includeLP = s => s === 'languagePicker-config'
+    const excludeLP = () => false
+    const registrySchema = library.schemas.config
+    const withLPSchema = await library.getSchema('config', { useCache: false, extensionFilter: includeLP })
+    const withoutLPSchema = await library.getSchema('config', { useCache: false, extensionFilter: excludeLP })
+    const withLPHas = '_languagePicker' in (withLPSchema.built.properties ?? {})
+    const withoutLPHas = '_languagePicker' in (withoutLPSchema.built.properties ?? {})
+    console.log(`  ✓ Filter-include build has _languagePicker: ${withLPHas}`)
+    console.log(`  ✓ Filter-exclude build lacks _languagePicker: ${!withoutLPHas}`)
+    // earlier build's properties must not be mutated by the later build (the original race)
+    const withLPStillHas = '_languagePicker' in (withLPSchema.built.properties ?? {})
+    console.log(`  ✓ Earlier filter-include build is unaffected by later call: ${withLPStillHas}`)
+    // each filtered call must return a fresh instance, not the registry one
+    const isolatedFromRegistry = withLPSchema !== registrySchema && withoutLPSchema !== registrySchema && withLPSchema !== withoutLPSchema
+    console.log(`  ✓ Filtered builds return isolated Schema instances: ${isolatedFromRegistry}`)
+    if (!withLPHas || withoutLPHas || !withLPStillHas || !isolatedFromRegistry) {
+      throw new Error('useCache:false did not isolate filtered builds from the registry')
+    }
+    console.log('')
+
     console.log('=== All tests passed! ===')
   } finally {
     if (!hasSpecifiedPath) {

--- a/test.js
+++ b/test.js
@@ -851,6 +851,41 @@ async function runTests () {
     }
     console.log('')
 
+    // Test 24: deregisterSchema cleans up extension references (issue #37)
+    console.log('Test 24: deregisterSchema cleans up extension references (issue #37)')
+    const extPatchPath = path.join(testSchemaDir, 'patch-ext.schema.json')
+    await fs.writeFile(extPatchPath, JSON.stringify({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $anchor: 'patch-ext',
+      type: 'object',
+      $patch: { source: { $ref: 'config' }, with: { properties: { _patchAdded: { type: 'string', default: 'added' } } } }
+    }, null, 2))
+    library.registerSchema(extPatchPath)
+    const beforeDeregister = library.schemaExtensions.config?.includes('patch-ext')
+    console.log(`  ✓ Extension registered against base: ${beforeDeregister}`)
+    const builtWithExt = (await library.getSchema('config')).built
+    const hasPatchedProperty = '_patchAdded' in (builtWithExt.properties ?? {})
+    console.log(`  ✓ Patched property visible in cached build: ${hasPatchedProperty}`)
+    library.deregisterSchema('patch-ext')
+    const afterDeregister = !library.schemaExtensions.config?.includes('patch-ext')
+    console.log(`  ✓ Extension removed from base after deregister: ${afterDeregister}`)
+    const cacheInvalidated = library.schemas.config?.built === undefined
+    console.log(`  ✓ Base cached build invalidated on deregister: ${cacheInvalidated}`)
+    let buildSucceeded = true
+    let postRebuildHasPatch = true
+    try {
+      const rebuilt = (await library.getSchema('config')).built
+      postRebuildHasPatch = '_patchAdded' in (rebuilt.properties ?? {})
+    } catch (e) {
+      buildSucceeded = false
+    }
+    console.log(`  ✓ Cached rebuild of base after deregister succeeds: ${buildSucceeded}`)
+    console.log(`  ✓ Patched property gone from rebuilt schema: ${!postRebuildHasPatch}`)
+    if (!beforeDeregister || !hasPatchedProperty || !afterDeregister || !cacheInvalidated || !buildSucceeded || postRebuildHasPatch) {
+      throw new Error('deregisterSchema did not clean up extension references and cached builds correctly')
+    }
+    console.log('')
+
     console.log('=== All tests passed! ===')
   } finally {
     if (!hasSpecifiedPath) {


### PR DESCRIPTION
### Fixes #37

### Breaking

- Removed `Schema.extensions` instance field. Extensions are now stored only on the library (`Schemas.schemaExtensions[baseName]`).
- Removed `Schema.addExtension(name)`. Use `Schemas.extendSchema(base, name)` instead.

### Fix

- `Schemas.deregisterSchema` now cleans up references to the deregistered schema from base schemas' extension lists. Stale references previously caused `MISSING_SCHEMA` on the next forced rebuild (e.g. after a content plugin uninstall).

### Update

- Ensure `Schemas.extendSchema` deduplicates (registering the same `(base, ext)` twice is a no-op)
- `Schemas.resetSchemaRegistry` now also clears `schemaExtensions`.
- `Schemas.getSchemaInfo()` reads extensions from the library map (return data unchanged for external callers).

### Test

- Adds [Test 19](https://github.com/cgkineo/adapt-schemas/blob/2787941e021318b5b30491465e0e4482dbe615ac/test.js#L577-L602)