### PR TITLE
Fix: Stop useCache: false from writing to the shared registry

### DIFF
--- a/lib/Schemas.js
+++ b/lib/Schemas.js
@@ -307,7 +307,7 @@ class Schemas extends EventEmitter {
    * Retrieves the specified schema
    * @param {string} schemaName The name of the schema to return
    * @param {Object} options
-   * @param {boolean} options.useCache Use cached build if available
+   * @param {boolean} options.useCache When false, builds into a fresh isolated Schema instance so per-call options (extensionFilter, applyExtensions) don't mutate the registry's build state (default: true)
    * @param {boolean} options.compile Compile the schema (default: true)
    * @param {boolean} options.applyExtensions Apply extension schemas (default: true)
    * @param {function} options.extensionFilter Filter function for extensions
@@ -318,7 +318,10 @@ class Schemas extends EventEmitter {
     if (!schema) {
       throw new SchemaError('MISSING_SCHEMA', `Schema '${schemaName}' not found`, { schemaName })
     }
-    return schema.build(options)
+    if (options.useCache !== false) return schema.build(options)
+    // build into a fresh instance so per-call options (e.g. extensionFilter) don't mutate the registry
+    const isolated = this.createSchema(schema.filePath, { enableCache: false })
+    return isolated.build(options)
   }
 
   /**

--- a/test.js
+++ b/test.js
@@ -886,6 +886,28 @@ async function runTests () {
     }
     console.log('')
 
+    // Test 25: useCache:false isolates filtered builds from the registry instance
+    console.log('Test 25: useCache:false isolates filtered builds from the registry instance')
+    const includeLP = s => s === 'languagePicker-config'
+    const excludeLP = () => false
+    const registrySchema = library.schemas.config
+    const withLPSchema = await library.getSchema('config', { useCache: false, extensionFilter: includeLP })
+    const withoutLPSchema = await library.getSchema('config', { useCache: false, extensionFilter: excludeLP })
+    const withLPHas = '_languagePicker' in (withLPSchema.built.properties ?? {})
+    const withoutLPHas = '_languagePicker' in (withoutLPSchema.built.properties ?? {})
+    console.log(`  ✓ Filter-include build has _languagePicker: ${withLPHas}`)
+    console.log(`  ✓ Filter-exclude build lacks _languagePicker: ${!withoutLPHas}`)
+    // earlier build's properties must not be mutated by the later build (the original race)
+    const withLPStillHas = '_languagePicker' in (withLPSchema.built.properties ?? {})
+    console.log(`  ✓ Earlier filter-include build is unaffected by later call: ${withLPStillHas}`)
+    // each filtered call must return a fresh instance, not the registry one
+    const isolatedFromRegistry = withLPSchema !== registrySchema && withoutLPSchema !== registrySchema && withLPSchema !== withoutLPSchema
+    console.log(`  ✓ Filtered builds return isolated Schema instances: ${isolatedFromRegistry}`)
+    if (!withLPHas || withoutLPHas || !withLPStillHas || !isolatedFromRegistry) {
+      throw new Error('useCache:false did not isolate filtered builds from the registry')
+    }
+    console.log('')
+
     console.log('=== All tests passed! ===')
   } finally {
     if (!hasSpecifiedPath) {


### PR DESCRIPTION
### Fixes #41

> Dependent on library-side extension storage change in #38

### Fix

- `Schemas.getSchema` now builds into a fresh isolated `Schema` instance when `useCache: false`, leaving the registry's `built` / `compiled` untouched. Concurrent callers passing different `extensionFilter`s no longer race.

- Default behaviour (`useCache: true` / unset) is unchanged — same shared registry instance, same cached build.

### Test

- Adds [Test 25](https://github.com/cgkineo/adapt-schemas/blob/fix/isolate-filtered-builds/test.js): two `getSchema(..., { useCache: false, extensionFilter })` calls with different filters produce independent builds; earlier build is not mutated by the later call; both return Schema instances distinct from the registry.